### PR TITLE
Extend IZivoeYDL Interface

### DIFF
--- a/src/misc/InterfacesAggregated.sol
+++ b/src/misc/InterfacesAggregated.sol
@@ -191,6 +191,7 @@ interface IZivoeYDL is GenericData {
     function protocolEarningsRateBIPS() external view returns (uint256);
     function daysBetweenDistributions() external view returns (uint256);
     function retrospectiveDistributions() external view returns (uint256);
+    function earningsTrancheuse(uint256, uint256) external view returns (uint256[] memory, uint256, uint256, uint256[] memory);
 }
 
 


### PR DESCRIPTION
This PR accomplishes the following:
- Extends the IZivoeYDL interface in the `InterfacesAggregated.sol` file