### PR TITLE
OCL_ZVE pre-audit review Alex

### DIFF
--- a/src/lockers/OCL/OCL_ZVE.sol
+++ b/src/lockers/OCL/OCL_ZVE.sol
@@ -231,15 +231,15 @@ contract OCL_ZVE is ZivoeLocker, ReentrancyGuard {
         // "pair" represents the liquidity pool token (minted, burned).
         // "pairAsset" represents the stablecoin paired against $ZVE.
         if (asset == pair) {
-            uint256 preBalLPToken = IERC20(pair).balanceOf(address(this));
-            IERC20(pair).safeApprove(router, preBalLPToken);
+            uint256 lpTokenBalance = IERC20(pair).balanceOf(address(this));
+            IERC20(pair).safeApprove(router, lpTokenBalance);
 
             // Router removeLiquidity() endpoint.
             (uint claimedPairAsset, uint claimedZVE) = IRouter_OCL_ZVE(router).removeLiquidity(
-                pairAsset, IZivoeGlobals_OCL_ZVE(GBL).ZVE(), preBalLPToken, 
+                pairAsset, IZivoeGlobals_OCL_ZVE(GBL).ZVE(), lpTokenBalance, 
                 0, 0, address(this), block.timestamp + 14 days
             );
-            emit LiquidityTokensBurned(preBalLPToken, claimedZVE, claimedPairAsset);
+            emit LiquidityTokensBurned(lpTokenBalance, claimedZVE, claimedPairAsset);
             assert(IERC20(pair).allowance(address(this), router) == 0);
 
             IERC20(pairAsset).safeTransfer(owner(), IERC20(pairAsset).balanceOf(address(this)));


### PR DESCRIPTION
This PR accomplishes the following:

-Accounting of `basis` is now calculated on both `pairAsset` and ZVE balances. (Previously on `pairAsset`).
This is needed because of the potential price volatility. In high volatility periods, we could think that the basis increased (in terms of `pairAsset`) while in reality we are subject to impermanent loss and would be selling LP tokens at a loss.
Therefore we are now considering `basis` as the total amount withdrawable (`pairAsset` + ZVE)  in `pairAsset` value.

Here are the formulas:

`basis` = pairAsset withdrawable + (ZVE withdrawable * ZVE priced in pairAsset)
ZVE priced in pairAsset = total pairAsset in pool / total ZVE in pool

-We also initiate a check if `basis > preBasis - postBasis` in `pullFromLockerPartial()`. 
This is needed when we are pulling more than `basis` amount (`basis < preBasis - postBasis`).
In that case the residual is equal to yield generated and `basis` is set to 0.

