### PR TITLE
maxTrancheRatioBIPS 4500->2000

### DIFF
--- a/src/ZivoeTranches.sol
+++ b/src/ZivoeTranches.sol
@@ -70,7 +70,7 @@ contract ZivoeTranches is ZivoeLocker, ReentrancyGuard {
 
     /// @dev This ratio represents the maximum size allowed for junior tranche, relative to senior tranche.
     ///      A value of 2,000 represent 20%, thus junior tranche at maximum can be 20% the size of senior tranche.
-    uint256 public maxTrancheRatioBIPS = 4500;
+    uint256 public maxTrancheRatioBIPS = 2000;
 
     /// @dev These two values control the min/max $ZVE minted per stablecoin deposited to ZivoeTranches.
     uint256 public minZVEPerJTTMint = 0;


### PR DESCRIPTION
This PR accomplishes the following:
- Updates `maxTrancheRatioBIPS` in ZivoeTranches from `4500` to `2000`