### PR TITLE
zvr vesting-logic require

### DIFF
--- a/src/ZivoeRewardsVesting.sol
+++ b/src/ZivoeRewardsVesting.sol
@@ -393,7 +393,7 @@ contract ZivoeRewardsVesting is ReentrancyGuard, Context, ZivoeVotes {
             IERC20(vestingToken).balanceOf(address(this)) - vestingTokenAllocated >= amountToVest, 
             "ZivoeRewardsVesting::createVestingSchedule() amountToVest > vestingToken.balanceOf(address(this)) - vestingTokenAllocated"
         );
-        require(daysToVest <= 1800 days, "ZivoeRewardsVesting::createVestingSchedule() daysToVest > 1800 days");
+        require(daysToVest <= 1800, "ZivoeRewardsVesting::createVestingSchedule() daysToVest > 1800");
         require(daysToCliff <= daysToVest, "ZivoeRewardsVesting::createVestingSchedule() daysToCliff > daysToVest");
         require(
             IZivoeITO_ZivoeRewardsVesting(IZivoeGlobals_ZivoeRewardsVesting(GBL).ITO()).seniorCredits(account) == 0 &&


### PR DESCRIPTION
This PR accomplishes the following:
- Updates ZivoeRewardsVesting require check in createVestingSchedule endpoint, removing the `days` tag