### PR TITLE
Feat/deposit reward whitelist

### DIFF
--- a/src/ZivoeGlobals.sol
+++ b/src/ZivoeGlobals.sol
@@ -45,7 +45,7 @@ contract ZivoeGlobals is Ownable {
 
     uint256 public defaults;    /// @dev Tracks net defaults in the system.
 
-    /// @dev Whitelist for keepers, responsible for pre-initiating actions.
+    /// @dev Whitelist for depositors, responsible for depositing rewards.
     mapping(address => bool) public isDepositor;
 
     /// @dev Whitelist for keepers, responsible for pre-initiating actions.

--- a/src/ZivoeGlobals.sol
+++ b/src/ZivoeGlobals.sol
@@ -12,6 +12,7 @@ import "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Met
 ///         This contract has the following responsibilities:
 ///          - Maintain accounting of all defaults within the system in aggregate.
 ///          - Handle ZVL AccessControl (switching to other wallets).
+///          - Whitelist management for "depositors" which are allowed to deposit into staking contracts.
 ///          - Whitelist management for "keepers" which are allowed to execute proposals within the TLC in advance.
 ///          - Whitelist management for "lockers" which ZivoeDAO can push/pull to.
 ///          - Whitelist management for "stablecoins" which are accepted in other Zivoe contracts.
@@ -43,6 +44,9 @@ contract ZivoeGlobals is Ownable {
     address public proposedZVL; /// @dev Interim contract for 2FA ZVL access control transfer.
 
     uint256 public defaults;    /// @dev Tracks net defaults in the system.
+
+    /// @dev Whitelist for keepers, responsible for pre-initiating actions.
+    mapping(address => bool) public isDepositor;
 
     /// @dev Whitelist for keepers, responsible for pre-initiating actions.
     mapping(address => bool) public isKeeper;
@@ -83,6 +87,11 @@ contract ZivoeGlobals is Ownable {
     /// @notice Emitted during initializeGlobals() and acceptZVL().
     /// @param  controller The address representing ZVL.
     event TransferredZVL(address indexed controller);
+
+    /// @notice Emitted during updateIsDepositor().
+    /// @param  depositor   The address whose status as a despositor is being modified.
+    /// @param  status      The new status of "depositor".
+    event UpdatedDepositorStatus(address indexed depositor, bool status);
 
     /// @notice Emitted during updateIsKeeper().
     /// @param  account The address whose status as a keeper is being modified.
@@ -217,6 +226,15 @@ contract ZivoeGlobals is Ownable {
         proposedZVL = address(0);
         ZVL = _msgSender();
         emit TransferredZVL(_msgSender());
+    }
+
+    /// @notice Updates the depositor whitelist.
+    /// @dev    This function MUST only be called by ZVL().
+    /// @param  depositor The address of the depositor.
+    /// @param  status The status to assign to the "depositor" (true = allowed, false = restricted).
+    function updateIsDepositor(address depositor, bool status) external onlyZVL {
+        emit UpdatedDepositorStatus(depositor, status);
+        isDepositor[depositor] = status;
     }
 
     /// @notice Updates the keeper whitelist.

--- a/src/ZivoeRewards.sol
+++ b/src/ZivoeRewards.sol
@@ -13,6 +13,9 @@ import "../lib/openzeppelin-contracts/contracts/utils/math/SafeMath.sol";
 interface IZivoeGlobals_ZivoeRewards {
     /// @notice Returns the address of the Zivoe Laboratory.
     function ZVL() external view returns (address);
+
+    /// @notice Returns true if an address is whitelisted as a depositor.
+    function isDepositor(address) external view returns (bool);
 }
 
 
@@ -226,6 +229,10 @@ contract ZivoeRewards is ReentrancyGuard, Context, ZivoeVotes {
     /// @param _rewardsToken The asset that's being distributed.
     /// @param reward The amount of the _rewardsToken to deposit.
     function depositReward(address _rewardsToken, uint256 reward) external updateReward(address(0)) nonReentrant {
+        require(
+            IZivoeGlobals_ZivoeRewards(GBL).isDepositor(_msgSender()),
+            "!IZivoeGlobals_ZivoeRewards(GBL).isDepositor(_msgSender())"
+        );
         IERC20(_rewardsToken).safeTransferFrom(_msgSender(), address(this), reward);
 
         // Update vesting accounting for reward (if existing rewards being distributed, increase proportionally).

--- a/src/ZivoeRewardsVesting.sol
+++ b/src/ZivoeRewardsVesting.sol
@@ -19,6 +19,9 @@ interface IZivoeGlobals_ZivoeRewardsVesting {
 
     /// @notice Returns the address of the Zivoe Laboratory.
     function ZVL() external view returns (address);
+
+    /// @notice Returns true if an address is whitelisted as a depositor.
+    function isDepositor(address) external view returns (bool);
 }
 
 interface IZivoeITO_ZivoeRewardsVesting {
@@ -350,6 +353,10 @@ contract ZivoeRewardsVesting is ReentrancyGuard, Context, ZivoeVotes {
     /// @param _rewardsToken The asset that's being distributed.
     /// @param reward The amount of the _rewardsToken to deposit.
     function depositReward(address _rewardsToken, uint256 reward) external updateReward(address(0)) nonReentrant {
+        require(
+            IZivoeGlobals_ZivoeRewardsVesting(GBL).isDepositor(_msgSender()),
+            "!IZivoeGlobals_ZivoeRewardsVesting(GBL).isDepositor(_msgSender())"
+        );
         IERC20(_rewardsToken).safeTransferFrom(_msgSender(), address(this), reward);
 
         // Update vesting accounting for reward (if existing rewards being distributed, increase proportionally).


### PR DESCRIPTION
This PR accomplishes the following:
- Adds a whitelist for depositors to ZivoeGlobals
- Adds a setter for this whitelist to ZivoeGlobals (along with event logs)
- Enforces this whitelist in ZivoeReward and ZivoeRewardsVesting for rewardDeposit() endpoint