### PR TITLE
Feat/oce zve upper bound

### DIFF
--- a/src/lockers/OCE/OCE_ZVE.sol
+++ b/src/lockers/OCE/OCE_ZVE.sol
@@ -189,6 +189,10 @@ contract OCE_ZVE is ZivoeLocker, ReentrancyGuard {
             _exponentialDecayPerSecond >= RAY * 99999998 / 100000000,
             "OCE_ZVE::updateExponentialDecayPerSecond() _exponentialDecayPerSecond < RAY * 99999998 / 100000000"
         );
+        require(
+            _exponentialDecayPerSecond < RAY,
+            "OCE_ZVE::updateExponentialDecayPerSecond() _exponentialDecayPerSecond >= RAY"
+        );
         emit UpdatedExponentialDecayPerSecond(exponentialDecayPerSecond, _exponentialDecayPerSecond);
         exponentialDecayPerSecond = _exponentialDecayPerSecond; 
     }


### PR DESCRIPTION
This PR accomplishes the following:
- Adds an upper-bound to the OCE_ZVE update endpoint, updateExponentialDecayPerSecond() capped at `RAY`