### PR TITLE
Instant Redemptions

### DIFF
--- a/src/lockers/OCC/OCC_Variable.sol
+++ b/src/lockers/OCC/OCC_Variable.sol
@@ -5,11 +5,6 @@ import "../../ZivoeLocker.sol";
 
 import "../../../lib/openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
 
-// Interface for zSTT burning
-interface IERC20Burnable_OCR { 
-    function burn(uint256 amount) external; 
-}
-
 // Interface for ZivoeGlobals
 interface IZivoeGlobals_OCC_Variable { 
     function YDL() external view returns (address);
@@ -156,14 +151,16 @@ contract OCC_Variable is ZivoeLocker, ReentrancyGuard {
     function repay(uint256 amount, uint256 base) external { 
         require(base <= amount, "OCC_Variable::repay() base > amount");
         require(amount <= usage[_msgSender()], "OCC_Variable::repay() amount > usage");
-        IERC20(USDC).safeTransferFrom(owner(), address(this), amount);
+        IERC20(USDC).safeTransferFrom(_msgSender(), address(this), amount);
 
         // "Amount - base" is forwarded to YDL.
         IERC20(USDC).safeTransfer(IZivoeGlobals_OCC_Variable(GBL).YDL(), amount - base);
         
         // "Base" is forwarded to DAO.
-        IERC20(USDC).safeTransfer(IZivoeGlobals_OCC_Variable(GBL).DAO(), base);
-        usage[_msgSender()] -= base;
+        if (base > 0) {
+            IERC20(USDC).safeTransfer(IZivoeGlobals_OCC_Variable(GBL).DAO(), base);
+            usage[_msgSender()] -= base;
+        }
 
         emit Repay(amount, base, _msgSender());
     }

--- a/src/lockers/OCC/OCC_Variable.sol
+++ b/src/lockers/OCC/OCC_Variable.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "../../ZivoeLocker.sol";
+
+import "../../../lib/openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
+
+// Interface for zSTT burning
+interface IERC20Burnable_OCR { 
+    function burn(uint256 amount) external; 
+}
+
+// Interface for ZivoeGlobals
+interface IZivoeGlobals_OCC_Variable { 
+    function YDL() external view returns (address);
+    function DAO() external view returns (address);
+}
+
+/// @notice  OCC stands for "On-Chain Credit", and Variable refers to supporting a variable payment.
+///          This locker is responsible for handling draw limits.
+///          This locker is responsible for handling payments, distributions, and for storing payment data.
+contract OCC_Variable is ZivoeLocker, ReentrancyGuard {
+
+    using SafeERC20 for IERC20;
+
+    // ---------------------
+    //    State Variables
+    // ---------------------
+
+    address public immutable GBL;                   /// @dev The ZivoeGlobals contract.
+    address public immutable USDC;                  /// @dev The USDC token contract.
+    address public immutable underwriter;           /// @dev The entity that manages draw limits.
+
+    mapping(address => uint256) public limit;      /// @dev The draw limit mapping.
+    mapping(address => uint256) public usage;      /// @dev The draw usage mapping.
+
+
+    // -----------------
+    //    Constructor
+    // -----------------
+
+    /// @notice Initializes the OCC_Variable contract.
+    /// @param  DAO The administrator of this contract (intended to be ZivoeDAO).
+    /// @param  _USDC The USDC token contract.
+    /// @param  _GBL The ZivoeGlobals contract.
+    /// @param  _underwriter The entity that manages draw limits.
+    constructor(
+        address DAO, 
+        address _USDC, 
+        address _GBL,
+        address _underwriter
+    ) {
+        transferOwnershipAndLock(DAO);
+        USDC = _USDC;
+        GBL = _GBL;
+        underwriter = _underwriter;
+    }
+
+
+
+    // ------------
+    //    Events
+    // ------------
+
+    /// @notice Emitted when a user draws USDC.
+    /// @param  amount The amount drawn.
+    /// @param  user The user that drew the funds.
+    event Draw(uint256 amount, address user);
+
+    /// @notice Emitted when a user repays USDC.
+    /// @param  amount The amount repaid.
+    /// @param  base The base amount repaid.
+    /// @param  user The user that repaid the funds.
+    event Repay(uint256 amount, uint256 base, address user);
+
+    /// @notice Emitted when the underwriter adjusts a draw limit.
+    /// @param  amount The amount to adjust the limit to.
+    /// @param  user The user to adjust the limit for.
+    event AdjustLimit(uint256 amount, address user);
+    
+
+    // ---------------
+    //    Modifiers
+    // ---------------
+
+    /// @notice This modifier ensures that the caller is the entity that is allowed to issue loans.
+    modifier isUnderwriter() {
+        require(_msgSender() == underwriter, "OCC_Variable::isUnderwriter() _msgSender() != underwriter");
+        _;
+    }
+
+
+    // ---------------
+    //    Functions
+    // ---------------
+
+    /// @notice Permission for owner to call pushToLocker().
+    function canPush() public override pure returns (bool) { return true; }
+
+    /// @notice Permission for owner to call pullFromLocker().
+    function canPull() public override pure returns (bool) { return true; }
+
+    /// @notice Permission for owner to call pullFromLockerPartial().
+    function canPullPartial() public override pure returns (bool) { return true; }
+
+    /// @notice This pulls capital from the DAO and deposits it into this contract
+    /// @param  asset The asset to pull from the DAO.
+    /// @param  amount The amount of asset to pull from the DAO.
+    /// @param  data Accompanying transaction data.
+    function pushToLocker(
+        address asset, uint256 amount, bytes calldata data
+    ) external override onlyOwner nonReentrant {
+        require(asset == USDC, "OCC_Variable::pushToLocker() asset != USDC");
+        IERC20(asset).safeTransferFrom(owner(), address(this), amount);
+    }
+
+    /// @notice Migrates entire ERC20 balance from locker to owner().
+    /// @param  asset The asset to migrate.
+    /// @param  data Accompanying transaction data.
+    function pullFromLocker(address asset, bytes calldata data) external override onlyOwner nonReentrant {
+        require(asset == USDC, "OCC_Variable::pullFromLocker() asset != USDC");
+        IERC20(USDC).safeTransfer(owner(), IERC20(USDC).balanceOf(address(this)));
+    }
+
+    /// @notice Migrates specific amount of ERC20 from locker to owner().
+    /// @param  asset The asset to migrate.
+    /// @param  amount The amount of "asset" to migrate.
+    /// @param  data Accompanying transaction data.
+    function pullFromLockerPartial(
+        address asset, uint256 amount, bytes calldata data
+    ) external override onlyOwner nonReentrant {
+        require(asset == USDC, "OCC_Variable::pullFromLockerPartial() asset != USDC");
+        IERC20(USDC).safeTransfer(owner(), amount);
+    }
+
+    /// @notice Adjusts the limit for a particular user.
+    /// @param  amount The amount to adjust the limit to.
+    /// @param  user The user to adjust the limit for.
+    function adjustLimit(uint256 amount, address user) external isUnderwriter { 
+        limit[user] = amount;
+        emit AdjustLimit(amount, user);
+    }
+
+    /// @notice Draw from OCC_Variable.
+    /// @param  amount The amount to draw.
+    function draw(uint256 amount) external { 
+        require(amount + usage[_msgSender()] <= limit[_msgSender()], "OCC_Variable::draw() amount + usage > limit");
+        usage[_msgSender()] += amount;
+        IERC20(USDC).safeTransfer(_msgSender(), amount);
+        emit Draw(amount, _msgSender());
+    }
+
+    /// @notice Repay to OCC_Variable.
+    /// @param  amount The amount to repay.
+    /// @param  base The base amount to repay.
+    function repay(uint256 amount, uint256 base) external { 
+        require(base <= amount, "OCC_Variable::repay() base > amount");
+        require(amount <= usage[_msgSender()], "OCC_Variable::repay() amount > usage");
+        IERC20(USDC).safeTransferFrom(owner(), address(this), amount);
+
+        // "Amount - base" is forwarded to YDL.
+        IERC20(USDC).safeTransfer(IZivoeGlobals_OCC_Variable(GBL).YDL(), amount - base);
+        
+        // "Base" is forwarded to DAO.
+        IERC20(USDC).safeTransfer(IZivoeGlobals_OCC_Variable(GBL).DAO(), base);
+        usage[_msgSender()] -= base;
+
+        emit Repay(amount, base, _msgSender());
+    }
+
+
+}

--- a/src/lockers/OCR/OCR_Instant.sol
+++ b/src/lockers/OCR/OCR_Instant.sol
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "../../ZivoeLocker.sol";
+
+import "../../../lib/openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
+
+interface IERC20Burnable_OCR {
+    /// @notice Burns tokens.
+    /// @param  amount The number of tokens to burn.
+    function burn(uint256 amount) external;
+}
+
+interface IZivoeGlobals_OCR {
+    /// @notice Returns the address of the Timelock contract.
+    function TLC() external view returns (address);
+
+    /// @notice Returns the address of the $zJTT contract.
+    function zJTT() external view returns (address);
+
+    /// @notice Returns the address of the $zSTT contract.
+    function zSTT() external view returns (address);
+}
+
+// AAVE V3 Interfaces
+interface IPool {
+    function supply(
+        address asset,
+        uint256 amount,
+        address onBehalfOf,
+        uint16 referralCode
+    ) external;
+
+    function withdraw(
+        address asset,
+        uint256 amount,
+        address to
+    ) external returns (uint256);
+}
+
+interface IAToken {
+    function balanceOf(address user) external view returns (uint256);
+}
+
+/// @notice  OCR stands for "On-Chain Redemption".
+///          This locker is responsible for handling redemptions of tranche tokens to stablecoins.
+///          Now integrated with AAVE V3 USDC pool for instant redemptions.
+contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
+
+    using SafeERC20 for IERC20;
+
+    // ---------------------
+    //    State Variables
+    // ---------------------
+
+    address public immutable GBL;                   /// @dev The ZivoeGlobals contract.
+    address public immutable stablecoin;            /// @dev The stablecoin redeemable in this contract (USDC).
+    address public immutable zVLT;                  /// @dev The zVLT token contract.
+    address public immutable AAVE_V3_POOL;         /// @dev The AAVE V3 Pool contract.
+    address public immutable AAVE_V3_USDC_ATOKEN;  /// @dev The AAVE V3 USDC aToken contract.
+    
+    uint256 public redemptionsFeeBIPS;              /// @dev Fee for redemptions (in BIPS).
+
+    uint256 private constant BIPS = 10000;
+
+    // -----------------
+    //    Constructor
+    // -----------------
+
+    /// @notice Initializes the OCR_Instant contract.
+    /// @param  DAO The administrator of this contract (intended to be ZivoeDAO).
+    /// @param  _stablecoin The stablecoin redeemable in this OCR contract (USDC).
+    /// @param  _GBL The ZivoeGlobals contract.
+    /// @param  _zVLT The zVLT token contract.
+    /// @param  _AAVE_V3_POOL The AAVE V3 Pool contract.
+    /// @param  _AAVE_V3_USDC_ATOKEN The AAVE V3 USDC aToken contract.
+    /// @param  _redemptionsFeeBIPS Fee for redemptions (in BIPS).
+    constructor(
+        address DAO, 
+        address _stablecoin, 
+        address _GBL, 
+        address _zVLT,
+        address _AAVE_V3_POOL,
+        address _AAVE_V3_USDC_ATOKEN,
+        uint16 _redemptionsFeeBIPS
+    ) {
+        require(_redemptionsFeeBIPS <= 2000, "OCR_Instant::constructor() _redemptionsFeeBIPS > 2000");
+        transferOwnershipAndLock(DAO);
+        stablecoin = _stablecoin;
+        GBL = _GBL;
+        zVLT = _zVLT;
+        AAVE_V3_POOL = _AAVE_V3_POOL;
+        AAVE_V3_USDC_ATOKEN = _AAVE_V3_USDC_ATOKEN;
+        redemptionsFeeBIPS = _redemptionsFeeBIPS;
+    }
+
+    // ------------
+    //    Events
+    // ------------
+
+    /// @notice Emitted during updateRedemptionsFee().
+    /// @param  oldFee The old value of redemptionsFeeBIPS.
+    /// @param  newFee The new value of redemptionsFeeBIPS.
+    event UpdatedRedemptionsFeeBIPS(uint256 oldFee, uint256 newFee);
+
+    /// @notice Emitted when USDC is deposited to AAVE V3.
+    /// @param  amount The amount of USDC deposited.
+    /// @param  aTokenBalance The resulting aToken balance.
+    event USDCDepositedToAAVE(uint256 amount, uint256 aTokenBalance);
+
+    /// @notice Emitted when USDC is withdrawn from AAVE V3.
+    /// @param  amount The amount of USDC withdrawn.
+    /// @param  aTokenBurned The amount of aTokens burned.
+    event USDCWithdrawnFromAAVE(uint256 amount, uint256 aTokenBurned);
+
+    /// @notice Emitted when zVLT tokens are burned for USDC redemption.
+    /// @param  user The user burning zVLT tokens.
+    /// @param  zVLTBurned The amount of zVLT tokens burned.
+    /// @param  usdcReceived The amount of USDC received.
+    /// @param  fee The fee taken.
+    event zVLTBurnedForUSDC(address indexed user, uint256 zVLTBurned, uint256 usdcReceived, uint256 fee);
+
+    // ---------------
+    //    Functions
+    // ---------------
+
+    /// @notice Permission for owner to call pushToLocker().
+    function canPush() public override pure returns (bool) { return true; }
+
+    /// @notice Permission for owner to call pullFromLocker().
+    function canPull() public override pure returns (bool) { return true; }
+
+    /// @notice Permission for owner to call pullFromLockerPartial().
+    function canPullPartial() public override pure returns (bool) { return true; }
+
+    /// @notice This pulls capital from the DAO and deposits it into AAVE V3 USDC pool.
+    /// @param  asset The asset to pull from the DAO.
+    /// @param  amount The amount of asset to pull from the DAO.
+    /// @param  data Accompanying transaction data.
+    function pushToLocker(
+        address asset, uint256 amount, bytes calldata data
+    ) external override _tickEpoch onlyOwner nonReentrant {
+        require(asset == stablecoin, "OCR_Instant::pushToLocker() asset != stablecoin");
+        
+        // Transfer USDC from DAO to this contract
+        IERC20(asset).safeTransferFrom(owner(), address(this), amount);
+        
+        // Approve AAVE V3 Pool to spend USDC
+        IERC20(asset).safeApprove(AAVE_V3_POOL, amount);
+        
+        // Deposit USDC into AAVE V3 pool
+        IPool(AAVE_V3_POOL).supply(asset, amount, address(this), 0);
+        
+        emit USDCDepositedToAAVE(amount, IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this)));
+    }
+
+    /// @notice Migrates entire ERC20 balance from locker to owner(), withdrawing from AAVE V3 if needed.
+    /// @param  asset The asset to migrate.
+    /// @param  data Accompanying transaction data.
+    function pullFromLocker(address asset, bytes calldata data) external override _tickEpoch onlyOwner nonReentrant {
+        require(
+            asset != IZivoeGlobals_OCR(GBL).zJTT() && asset != IZivoeGlobals_OCR(GBL).zSTT(),
+            "OCR_Instant::pullFromLocker() asset == zJTT || asset == zSTT"
+        );
+        
+        if (asset == stablecoin) {
+            // Withdraw all USDC from AAVE V3 pool
+            uint256 aTokenBalance = IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this));
+            if (aTokenBalance > 0) {
+                IPool(AAVE_V3_POOL).withdraw(asset, type(uint256).max, address(this));
+                emit USDCWithdrawnFromAAVE(IERC20(asset).balanceOf(address(this)), aTokenBalance);
+            }
+        }
+        
+        IERC20(asset).safeTransfer(owner(), IERC20(asset).balanceOf(address(this)));
+    }
+
+    /// @notice Migrates specific amount of ERC20 from locker to owner(), withdrawing from AAVE V3 if needed.
+    /// @param  asset The asset to migrate.
+    /// @param  amount The amount of "asset" to migrate.
+    /// @param  data Accompanying transaction data.
+    function pullFromLockerPartial(
+        address asset, uint256 amount, bytes calldata data
+    ) external override _tickEpoch onlyOwner nonReentrant {
+        require(
+            asset != IZivoeGlobals_OCR(GBL).zJTT() && asset != IZivoeGlobals_OCR(GBL).zSTT(),
+            "OCR_Instant::pullFromLockerPartial() asset == zJTT || asset == zSTT"
+        );
+        
+        if (asset == stablecoin) {
+            // Check if we need to withdraw from AAVE V3 to meet the requested amount
+            uint256 currentBalance = IERC20(asset).balanceOf(address(this));
+            if (currentBalance < amount) {
+                uint256 neededFromAAVE = amount - currentBalance;
+                uint256 aTokenBalance = IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this));
+                
+                // Calculate how much we can withdraw (limited by aToken balance)
+                uint256 withdrawAmount = neededFromAAVE > aTokenBalance ? aTokenBalance : neededFromAAVE;
+                
+                if (withdrawAmount > 0) {
+                    IPool(AAVE_V3_POOL).withdraw(asset, withdrawAmount, address(this));
+                    emit USDCWithdrawnFromAAVE(withdrawAmount, withdrawAmount);
+                }
+            }
+        }
+        
+        IERC20(asset).safeTransfer(owner(), amount);
+    }
+
+    /// @notice Allows users to burn their zVLT tokens to receive USDC.
+    /// @param  zVLTAmount The amount of zVLT tokens to burn.
+    function burnZVLTForUSDC(uint256 zVLTAmount) external nonReentrant {
+        require(zVLTAmount > 0, "OCR_Instant::burnZVLTForUSDC() zVLTAmount == 0");
+        
+        // Calculate fee
+        uint256 fee = (zVLTAmount * redemptionsFeeBIPS) / BIPS;
+        uint256 netAmount = zVLTAmount - fee;
+        
+        // Burn zVLT tokens from user
+        IERC20Burnable_OCR(zVLT).burn(zVLTAmount);
+        
+        // Calculate how much USDC to provide (1:1 ratio for simplicity, can be adjusted)
+        uint256 usdcToProvide = netAmount;
+        
+        // Check if we have enough USDC in contract, if not withdraw from AAVE V3
+        uint256 currentUSDCBalance = IERC20(stablecoin).balanceOf(address(this));
+        if (currentUSDCBalance < usdcToProvide) {
+            uint256 neededFromAAVE = usdcToProvide - currentUSDCBalance;
+            uint256 aTokenBalance = IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this));
+            
+            // Calculate how much we can withdraw (limited by aToken balance)
+            uint256 withdrawAmount = neededFromAAVE > aTokenBalance ? aTokenBalance : neededFromAAVE;
+            
+            if (withdrawAmount > 0) {
+                IPool(AAVE_V3_POOL).withdraw(stablecoin, withdrawAmount, address(this));
+                emit USDCWithdrawnFromAAVE(withdrawAmount, withdrawAmount);
+            }
+        }
+        
+        // Transfer USDC to user
+        IERC20(stablecoin).safeTransfer(_msgSender(), usdcToProvide);
+        
+        emit zVLTBurnedForUSDC(_msgSender(), zVLTAmount, usdcToProvide, fee);
+    }
+
+    /// @notice Updates the state variable "redemptionsFeeBIPS".
+    /// @param  _redemptionsFeeBIPS The new value for redemptionsFeeBIPS (in BIPS).
+    function updateRedemptionsFeeBIPS(uint256 _redemptionsFeeBIPS) external _tickEpoch {
+        require(
+            _msgSender() == IZivoeGlobals_OCR(GBL).TLC(), 
+            "OCR_Instant::updateRedemptionsFeeBIPS() _msgSender() != TLC()"
+        );
+        require(
+            _redemptionsFeeBIPS <= 2000, "OCR_Instant::updateRedemptionsFeeBIPS() _redemptionsFeeBIPS > 2000"
+        );
+        emit UpdatedRedemptionsFeeBIPS(redemptionsFeeBIPS, _redemptionsFeeBIPS);
+        redemptionsFeeBIPS = _redemptionsFeeBIPS;
+    }
+
+    /// @notice Returns the current USDC balance available for redemptions.
+    /// @return The total USDC balance (contract + AAVE V3).
+    function getAvailableUSDCBalance() external view returns (uint256) {
+        uint256 contractBalance = IERC20(stablecoin).balanceOf(address(this));
+        uint256 aTokenBalance = IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this));
+        return contractBalance + aTokenBalance;
+    }
+
+    /// @notice Returns the AAVE V3 aToken balance for this contract.
+    /// @return The aToken balance.
+    function getATokenBalance() external view returns (uint256) {
+        return IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this));
+    }
+}

--- a/src/lockers/OCR/OCR_Instant.sol
+++ b/src/lockers/OCR/OCR_Instant.sol
@@ -191,10 +191,10 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
         uint256 zSTTReceived = IERC4626(zVLT).convertToAssets(zVLTAmount);
         
         // Calculate fee based on zSTT amount (same logic as redeemUSDC)
-        fee = (zSTTReceived * redemptionFeeBIPS) / BIPS;
+        fee = ((zSTTReceived * redemptionFeeBIPS) / BIPS) / 10**12;
         
         // Calculate net USDC amount after fees
-        usdcAmount = zSTTReceived - fee;
+        usdcAmount = zSTTReceived / 10**12 - fee;
         
         return (usdcAmount, fee);
     }
@@ -214,18 +214,18 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
         // Burn zSTT
         IERC20Burnable_OCR(zSTT).burn(zSTTReceived);
 
+        // Calculate fee
+        uint256 fee = ((zSTTReceived * redemptionFeeBIPS) / BIPS) / 10**12;
+        uint256 netAmount = zSTTReceived / 10**12 - fee;
+
         // Revert if aUSDC balance is less than zSTTReceived
         uint256 aUSDCBalance = IERC20(aUSDC).balanceOf(address(this));
-        require(aUSDCBalance >= zSTTReceived, "OCR_Instant::redeemUSDC() aUSDCBalance < zSTTReceived");
-        
-        // Calculate fee
-        uint256 fee = (zSTTReceived * redemptionFeeBIPS) / BIPS;
-        uint256 netAmount = zSTTReceived - fee;
+        require(aUSDCBalance >= zSTTReceived / 10**12 - fee, "OCR_Instant::redeemUSDC() aUSDCBalance < zSTTReceived / 10**12 - fee");
 
-        // Calculate how much USDC to provide (1:1 ratio with zSTT burned)
+        // Calculate how much USDC to provide (1:1 ratio with zSTT burned, decimal precision rounded down 10**12)
         IPool_OCR(AAVE_V3_POOL).withdraw(USDC, netAmount, address(this));
 
-        // Transfer USDC to user and DAO
+        // Transfer USDC to user
         IERC20(USDC).safeTransfer(_msgSender(), netAmount);
         
         emit zVLTBurnedForUSDC(_msgSender(), zVLTAmount, netAmount, fee);

--- a/src/lockers/OCR/OCR_Instant.sol
+++ b/src/lockers/OCR/OCR_Instant.sol
@@ -5,46 +5,31 @@ import "../../ZivoeLocker.sol";
 
 import "../../../lib/openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
 
-interface IERC20Burnable_OCR {
-    /// @notice Burns tokens.
-    /// @param  amount The number of tokens to burn.
-    function burn(uint256 amount) external;
+// ERC-4626 Vault interface for zVLT
+interface IERC4626 {
+    function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
+    function convertToAssets(uint256 shares) external view returns (uint256 assets);
 }
 
-interface IZivoeGlobals_OCR {
-    /// @notice Returns the address of the Timelock contract.
-    function TLC() external view returns (address);
-
-    /// @notice Returns the address of the $zJTT contract.
-    function zJTT() external view returns (address);
-
-    /// @notice Returns the address of the $zSTT contract.
-    function zSTT() external view returns (address);
+// Interface for zSTT burning
+interface IERC20Burnable_OCR { 
+    function burn(uint256 amount) external; 
 }
 
-// AAVE V3 Interfaces
-interface IPool {
-    function supply(
-        address asset,
-        uint256 amount,
-        address onBehalfOf,
-        uint16 referralCode
-    ) external;
-
-    function withdraw(
-        address asset,
-        uint256 amount,
-        address to
-    ) external returns (uint256);
+// Interface for ZivoeGlobals
+interface IZivoeGlobals_OCR { 
+    function ZVL() external view returns (address);
 }
 
-interface IAToken {
-    function balanceOf(address user) external view returns (uint256);
+// AAVE V3 Pool interface
+interface IPool_OCR {
+    function supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
+    function withdraw(address asset, uint256 amount, address to) external returns (uint256);
 }
 
 /// @notice  OCR stands for "On-Chain Redemption".
-///          This locker is responsible for handling redemptions of tranche tokens to stablecoins.
-///          Now integrated with AAVE V3 USDC pool for instant redemptions.
+///          This locker is responsible for handling redemptions of zVLT for stablecoins.
+///          Integrated with AAVE V3 USDC pool for yield generation.
 contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
 
     using SafeERC20 for IERC20;
@@ -54,14 +39,17 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
     // ---------------------
 
     address public immutable GBL;                   /// @dev The ZivoeGlobals contract.
-    address public immutable stablecoin;            /// @dev The stablecoin redeemable in this contract (USDC).
-    address public immutable zVLT;                  /// @dev The zVLT token contract.
-    address public immutable AAVE_V3_POOL;         /// @dev The AAVE V3 Pool contract.
-    address public immutable AAVE_V3_USDC_ATOKEN;  /// @dev The AAVE V3 USDC aToken contract.
+    address public immutable USDC;                  /// @dev The USDC token contract.
+    address public immutable zVLT;                  /// @dev The zVLT ERC-4626 vault token contract.
+    address public immutable zSTT;                  /// @dev The zSTT underlying asset token contract.
+    address public immutable AAVE_V3_POOL;          /// @dev The AAVE V3 Pool contract.
+    address public immutable aUSDC;                 /// @dev The AAVE V3 USDC aToken contract.
     
-    uint256 public redemptionsFeeBIPS;              /// @dev Fee for redemptions (in BIPS).
+    uint256 public redemptionFeeBIPS;               /// @dev Fee for redemptions (in BIPS).
 
     uint256 private constant BIPS = 10000;
+
+
 
     // -----------------
     //    Constructor
@@ -69,39 +57,44 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
 
     /// @notice Initializes the OCR_Instant contract.
     /// @param  DAO The administrator of this contract (intended to be ZivoeDAO).
-    /// @param  _stablecoin The stablecoin redeemable in this OCR contract (USDC).
+    /// @param  _USDC The USDC token contract.
     /// @param  _GBL The ZivoeGlobals contract.
-    /// @param  _zVLT The zVLT token contract.
+    /// @param  _zVLT The zVLT ERC-4626 vault token contract.
+    /// @param  _zSTT The zSTT underlying asset token contract.
     /// @param  _AAVE_V3_POOL The AAVE V3 Pool contract.
-    /// @param  _AAVE_V3_USDC_ATOKEN The AAVE V3 USDC aToken contract.
-    /// @param  _redemptionsFeeBIPS Fee for redemptions (in BIPS).
+    /// @param  _aUSDC The AAVE V3 USDC aToken contract.
+    /// @param  _redemptionFeeBIPS Fee for redemptions (in BIPS).
     constructor(
         address DAO, 
-        address _stablecoin, 
+        address _USDC, 
         address _GBL, 
         address _zVLT,
+        address _zSTT,
         address _AAVE_V3_POOL,
-        address _AAVE_V3_USDC_ATOKEN,
-        uint16 _redemptionsFeeBIPS
+        address _aUSDC,
+        uint16 _redemptionFeeBIPS
     ) {
-        require(_redemptionsFeeBIPS <= 2000, "OCR_Instant::constructor() _redemptionsFeeBIPS > 2000");
+        require(_redemptionFeeBIPS <= 750, "OCR_Instant::constructor() _redemptionFeeBIPS > 750");
         transferOwnershipAndLock(DAO);
-        stablecoin = _stablecoin;
+        USDC = _USDC;
         GBL = _GBL;
         zVLT = _zVLT;
+        zSTT = _zSTT;
         AAVE_V3_POOL = _AAVE_V3_POOL;
-        AAVE_V3_USDC_ATOKEN = _AAVE_V3_USDC_ATOKEN;
-        redemptionsFeeBIPS = _redemptionsFeeBIPS;
+        aUSDC = _aUSDC;
+        redemptionFeeBIPS = _redemptionFeeBIPS;
     }
+
+
 
     // ------------
     //    Events
     // ------------
 
-    /// @notice Emitted during updateRedemptionsFee().
-    /// @param  oldFee The old value of redemptionsFeeBIPS.
-    /// @param  newFee The new value of redemptionsFeeBIPS.
-    event UpdatedRedemptionsFeeBIPS(uint256 oldFee, uint256 newFee);
+    /// @notice Emitted during updateRedemptionFee().
+    /// @param  oldFee The old value of redemptionFeeBIPS.
+    /// @param  newFee The new value of redemptionFeeBIPS.
+    event UpdatedRedemptionFeeBIPS(uint256 oldFee, uint256 newFee);
 
     /// @notice Emitted when USDC is deposited to AAVE V3.
     /// @param  amount The amount of USDC deposited.
@@ -116,9 +109,11 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
     /// @notice Emitted when zVLT tokens are burned for USDC redemption.
     /// @param  user The user burning zVLT tokens.
     /// @param  zVLTBurned The amount of zVLT tokens burned.
-    /// @param  usdcReceived The amount of USDC received.
+    /// @param  USDCRedeemed The amount of USDC sent to user.
     /// @param  fee The fee taken.
-    event zVLTBurnedForUSDC(address indexed user, uint256 zVLTBurned, uint256 usdcReceived, uint256 fee);
+    event zVLTBurnedForUSDC(address indexed user, uint256 zVLTBurned, uint256 USDCRedeemed, uint256 fee);
+
+
 
     // ---------------
     //    Functions
@@ -139,8 +134,8 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
     /// @param  data Accompanying transaction data.
     function pushToLocker(
         address asset, uint256 amount, bytes calldata data
-    ) external override _tickEpoch onlyOwner nonReentrant {
-        require(asset == stablecoin, "OCR_Instant::pushToLocker() asset != stablecoin");
+    ) external override onlyOwner nonReentrant {
+        require(asset == USDC, "OCR_Instant::pushToLocker() asset != USDC");
         
         // Transfer USDC from DAO to this contract
         IERC20(asset).safeTransferFrom(owner(), address(this), amount);
@@ -149,30 +144,23 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
         IERC20(asset).safeApprove(AAVE_V3_POOL, amount);
         
         // Deposit USDC into AAVE V3 pool
-        IPool(AAVE_V3_POOL).supply(asset, amount, address(this), 0);
+        IPool_OCR(AAVE_V3_POOL).supply(asset, amount, address(this), 0);
         
-        emit USDCDepositedToAAVE(amount, IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this)));
+        emit USDCDepositedToAAVE(amount, IERC20(aUSDC).balanceOf(address(this)));
     }
 
     /// @notice Migrates entire ERC20 balance from locker to owner(), withdrawing from AAVE V3 if needed.
     /// @param  asset The asset to migrate.
     /// @param  data Accompanying transaction data.
-    function pullFromLocker(address asset, bytes calldata data) external override _tickEpoch onlyOwner nonReentrant {
-        require(
-            asset != IZivoeGlobals_OCR(GBL).zJTT() && asset != IZivoeGlobals_OCR(GBL).zSTT(),
-            "OCR_Instant::pullFromLocker() asset == zJTT || asset == zSTT"
-        );
+    function pullFromLocker(address asset, bytes calldata data) external override onlyOwner nonReentrant {
+        require(asset == aUSDC, "OCR_Instant::pullFromLocker() asset != aUSDC");
         
-        if (asset == stablecoin) {
-            // Withdraw all USDC from AAVE V3 pool
-            uint256 aTokenBalance = IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this));
-            if (aTokenBalance > 0) {
-                IPool(AAVE_V3_POOL).withdraw(asset, type(uint256).max, address(this));
-                emit USDCWithdrawnFromAAVE(IERC20(asset).balanceOf(address(this)), aTokenBalance);
-            }
-        }
+        // Withdraw all USDC from AAVE V3 pool
+        uint256 aTokenBalance = IERC20(aUSDC).balanceOf(address(this));
+        IPool_OCR(AAVE_V3_POOL).withdraw(USDC, aTokenBalance, address(this));
+        emit USDCWithdrawnFromAAVE(IERC20(USDC).balanceOf(address(this)), aTokenBalance);
         
-        IERC20(asset).safeTransfer(owner(), IERC20(asset).balanceOf(address(this)));
+        IERC20(USDC).safeTransfer(owner(), IERC20(USDC).balanceOf(address(this)));
     }
 
     /// @notice Migrates specific amount of ERC20 from locker to owner(), withdrawing from AAVE V3 if needed.
@@ -181,27 +169,14 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
     /// @param  data Accompanying transaction data.
     function pullFromLockerPartial(
         address asset, uint256 amount, bytes calldata data
-    ) external override _tickEpoch onlyOwner nonReentrant {
-        require(
-            asset != IZivoeGlobals_OCR(GBL).zJTT() && asset != IZivoeGlobals_OCR(GBL).zSTT(),
-            "OCR_Instant::pullFromLockerPartial() asset == zJTT || asset == zSTT"
-        );
+    ) external override onlyOwner nonReentrant {
+        require(asset == aUSDC, "OCR_Instant::pullFromLockerPartial() asset != aUSDC");
         
-        if (asset == stablecoin) {
-            // Check if we need to withdraw from AAVE V3 to meet the requested amount
-            uint256 currentBalance = IERC20(asset).balanceOf(address(this));
-            if (currentBalance < amount) {
-                uint256 neededFromAAVE = amount - currentBalance;
-                uint256 aTokenBalance = IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this));
-                
-                // Calculate how much we can withdraw (limited by aToken balance)
-                uint256 withdrawAmount = neededFromAAVE > aTokenBalance ? aTokenBalance : neededFromAAVE;
-                
-                if (withdrawAmount > 0) {
-                    IPool(AAVE_V3_POOL).withdraw(asset, withdrawAmount, address(this));
-                    emit USDCWithdrawnFromAAVE(withdrawAmount, withdrawAmount);
-                }
-            }
+        // Check if we need to withdraw from AAVE V3 to meet the requested amount
+        uint256 currentBalance = IERC20(aUSDC).balanceOf(address(this));
+        if (currentBalance <= amount) {
+            IPool_OCR(AAVE_V3_POOL).withdraw(USDC, amount - currentBalance, address(this));
+            emit USDCWithdrawnFromAAVE(amount - currentBalance, amount - currentBalance);
         }
         
         IERC20(asset).safeTransfer(owner(), amount);
@@ -209,65 +184,48 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
 
     /// @notice Allows users to burn their zVLT tokens to receive USDC.
     /// @param  zVLTAmount The amount of zVLT tokens to burn.
-    function burnZVLTForUSDC(uint256 zVLTAmount) external nonReentrant {
-        require(zVLTAmount > 0, "OCR_Instant::burnZVLTForUSDC() zVLTAmount == 0");
+    function redeemUSDC(uint256 zVLTAmount) external nonReentrant {
+        require(zVLTAmount > 0, "OCR_Instant::redeemUSDC() zVLTAmount == 0");
         
+        // Transfer zVLT tokens from user to this contract
+        IERC20(zVLT).safeTransferFrom(_msgSender(), address(this), zVLTAmount);
+        
+        // Unwrap zVLT to get zSTT (underlying asset)
+        uint256 zSTTReceived = IERC4626(zVLT).redeem(zVLTAmount, address(this), address(this));
+
+        // Burn zSTT
+        IERC20Burnable_OCR(zSTT).burn(zSTTReceived);
+
+        // Revert if aUSDC balance is less than zSTTReceived
+        uint256 aUSDCBalance = IERC20(aUSDC).balanceOf(address(this));
+        require(aUSDCBalance >= zSTTReceived, "OCR_Instant::redeemUSDC() aUSDCBalance < zSTTReceived");
+        
+        // Calculate how much USDC to provide (1:1 ratio with zSTT burned)
+        IPool_OCR(AAVE_V3_POOL).withdraw(USDC, zSTTReceived, address(this));
+
         // Calculate fee
-        uint256 fee = (zVLTAmount * redemptionsFeeBIPS) / BIPS;
-        uint256 netAmount = zVLTAmount - fee;
+        uint256 fee = (zSTTReceived * redemptionFeeBIPS) / BIPS;
+        uint256 netAmount = zSTTReceived - fee;
+
+        // Transfer USDC to user and DAO
+        IERC20(USDC).safeTransfer(owner(), fee);
+        IERC20(USDC).safeTransfer(_msgSender(), netAmount);
         
-        // Burn zVLT tokens from user
-        IERC20Burnable_OCR(zVLT).burn(zVLTAmount);
-        
-        // Calculate how much USDC to provide (1:1 ratio for simplicity, can be adjusted)
-        uint256 usdcToProvide = netAmount;
-        
-        // Check if we have enough USDC in contract, if not withdraw from AAVE V3
-        uint256 currentUSDCBalance = IERC20(stablecoin).balanceOf(address(this));
-        if (currentUSDCBalance < usdcToProvide) {
-            uint256 neededFromAAVE = usdcToProvide - currentUSDCBalance;
-            uint256 aTokenBalance = IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this));
-            
-            // Calculate how much we can withdraw (limited by aToken balance)
-            uint256 withdrawAmount = neededFromAAVE > aTokenBalance ? aTokenBalance : neededFromAAVE;
-            
-            if (withdrawAmount > 0) {
-                IPool(AAVE_V3_POOL).withdraw(stablecoin, withdrawAmount, address(this));
-                emit USDCWithdrawnFromAAVE(withdrawAmount, withdrawAmount);
-            }
-        }
-        
-        // Transfer USDC to user
-        IERC20(stablecoin).safeTransfer(_msgSender(), usdcToProvide);
-        
-        emit zVLTBurnedForUSDC(_msgSender(), zVLTAmount, usdcToProvide, fee);
+        emit zVLTBurnedForUSDC(_msgSender(), zVLTAmount, netAmount, fee);
     }
 
-    /// @notice Updates the state variable "redemptionsFeeBIPS".
-    /// @param  _redemptionsFeeBIPS The new value for redemptionsFeeBIPS (in BIPS).
-    function updateRedemptionsFeeBIPS(uint256 _redemptionsFeeBIPS) external _tickEpoch {
+    /// @notice Updates the state variable "redemptionFeeBIPS".
+    /// @param  _redemptionFeeBIPS The new value for redemptionFeeBIPS (in BIPS).
+    function updateRedemptionFeeBIPS(uint256 _redemptionFeeBIPS) external {
         require(
-            _msgSender() == IZivoeGlobals_OCR(GBL).TLC(), 
-            "OCR_Instant::updateRedemptionsFeeBIPS() _msgSender() != TLC()"
+            _msgSender() == IZivoeGlobals_OCR(GBL).ZVL(), 
+            "OCR_Instant::updateRedemptionFeeBIPS() _msgSender() != ZVL()"
         );
         require(
-            _redemptionsFeeBIPS <= 2000, "OCR_Instant::updateRedemptionsFeeBIPS() _redemptionsFeeBIPS > 2000"
+            _redemptionFeeBIPS <= 750, "OCR_Instant::updateRedemptionFeeBIPS() _redemptionFeeBIPS > 750"
         );
-        emit UpdatedRedemptionsFeeBIPS(redemptionsFeeBIPS, _redemptionsFeeBIPS);
-        redemptionsFeeBIPS = _redemptionsFeeBIPS;
+        emit UpdatedRedemptionFeeBIPS(redemptionFeeBIPS, _redemptionFeeBIPS);
+        redemptionFeeBIPS = _redemptionFeeBIPS;
     }
 
-    /// @notice Returns the current USDC balance available for redemptions.
-    /// @return The total USDC balance (contract + AAVE V3).
-    function getAvailableUSDCBalance() external view returns (uint256) {
-        uint256 contractBalance = IERC20(stablecoin).balanceOf(address(this));
-        uint256 aTokenBalance = IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this));
-        return contractBalance + aTokenBalance;
-    }
-
-    /// @notice Returns the AAVE V3 aToken balance for this contract.
-    /// @return The aToken balance.
-    function getATokenBalance() external view returns (uint256) {
-        return IAToken(AAVE_V3_USDC_ATOKEN).balanceOf(address(this));
-    }
 }

--- a/src/lockers/OCR/OCR_Instant.sol
+++ b/src/lockers/OCR/OCR_Instant.sol
@@ -74,7 +74,7 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
         address _aUSDC,
         uint16 _redemptionFeeBIPS
     ) {
-        require(_redemptionFeeBIPS <= 750, "OCR_Instant::constructor() _redemptionFeeBIPS > 750");
+        require(_redemptionFeeBIPS <= 1000, "OCR_Instant::constructor() _redemptionFeeBIPS > 1000");
         transferOwnershipAndLock(DAO);
         USDC = _USDC;
         GBL = _GBL;
@@ -103,8 +103,8 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
 
     /// @notice Emitted when USDC is withdrawn from AAVE V3.
     /// @param  amount The amount of USDC withdrawn.
-    /// @param  aTokenBurned The amount of aTokens burned.
-    event USDCWithdrawnFromAAVE(uint256 amount, uint256 aTokenBurned);
+    /// @param  aTokenBalance The resulting aToken balance.
+    event USDCWithdrawnFromAAVE(uint256 amount, uint256 aTokenBalance);
 
     /// @notice Emitted when zVLT tokens are burned for USDC redemption.
     /// @param  user The user burning zVLT tokens.
@@ -158,7 +158,7 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
         // Withdraw all USDC from AAVE V3 pool
         uint256 aTokenBalance = IERC20(aUSDC).balanceOf(address(this));
         IPool_OCR(AAVE_V3_POOL).withdraw(USDC, aTokenBalance, address(this));
-        emit USDCWithdrawnFromAAVE(IERC20(USDC).balanceOf(address(this)), aTokenBalance);
+        emit USDCWithdrawnFromAAVE(IERC20(USDC).balanceOf(address(this)), 0);
         
         IERC20(USDC).safeTransfer(owner(), IERC20(USDC).balanceOf(address(this)));
     }
@@ -172,14 +172,12 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
     ) external override onlyOwner nonReentrant {
         require(asset == aUSDC, "OCR_Instant::pullFromLockerPartial() asset != aUSDC");
         
-        // Check if we need to withdraw from AAVE V3 to meet the requested amount
-        uint256 currentBalance = IERC20(aUSDC).balanceOf(address(this));
-        if (currentBalance <= amount) {
-            IPool_OCR(AAVE_V3_POOL).withdraw(USDC, amount - currentBalance, address(this));
-            emit USDCWithdrawnFromAAVE(amount - currentBalance, amount - currentBalance);
-        }
+        // Withdraw USDC from AAVE V3 pool for the requested aUSDC amount
+        IPool_OCR(AAVE_V3_POOL).withdraw(USDC, amount, address(this));
+        emit USDCWithdrawnFromAAVE(amount, IERC20(aUSDC).balanceOf(address(this)));
         
-        IERC20(asset).safeTransfer(owner(), amount);
+        // Transfer all USDC in the locker to the owner
+        IERC20(USDC).safeTransfer(owner(), IERC20(USDC).balanceOf(address(this)));
     }
 
     /// @notice Helper view function to determine how much USDC a given amount of zVLT will redeem for.
@@ -241,7 +239,7 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
             "OCR_Instant::updateRedemptionFeeBIPS() _msgSender() != ZVL()"
         );
         require(
-            _redemptionFeeBIPS <= 750, "OCR_Instant::updateRedemptionFeeBIPS() _redemptionFeeBIPS > 750"
+            _redemptionFeeBIPS <= 1000, "OCR_Instant::updateRedemptionFeeBIPS() _redemptionFeeBIPS > 1000"
         );
         emit UpdatedRedemptionFeeBIPS(redemptionFeeBIPS, _redemptionFeeBIPS);
         redemptionFeeBIPS = _redemptionFeeBIPS;

--- a/src/lockers/OCR/OCR_Instant.sol
+++ b/src/lockers/OCR/OCR_Instant.sol
@@ -182,6 +182,26 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
         IERC20(asset).safeTransfer(owner(), amount);
     }
 
+    /// @notice Helper view function to determine how much USDC a given amount of zVLT will redeem for.
+    /// @param  zVLTAmount The amount of zVLT tokens to calculate redemption for.
+    /// @return usdcAmount The amount of USDC that would be received after fees.
+    /// @return fee The fee amount that would be taken.
+    function calculateRedemptionAmount(uint256 zVLTAmount) external view returns (uint256 usdcAmount, uint256 fee) {
+        require(zVLTAmount > 0, "OCR_Instant::calculateRedemptionAmount() zVLTAmount == 0");
+        
+        // Calculate how much zSTT would be received from unwrapping zVLT
+        uint256 zSTTReceived = IERC4626(zVLT).convertToAssets(zVLTAmount);
+        
+        // Calculate fee based on zSTT amount (same logic as redeemUSDC)
+        fee = (zSTTReceived * redemptionFeeBIPS) / BIPS;
+        
+        // Calculate net USDC amount after fees
+        usdcAmount = zSTTReceived - fee;
+        
+        return (usdcAmount, fee);
+    }
+    
+
     /// @notice Allows users to burn their zVLT tokens to receive USDC.
     /// @param  zVLTAmount The amount of zVLT tokens to burn.
     function redeemUSDC(uint256 zVLTAmount) external nonReentrant {
@@ -200,15 +220,14 @@ contract OCR_Instant is ZivoeLocker, ReentrancyGuard {
         uint256 aUSDCBalance = IERC20(aUSDC).balanceOf(address(this));
         require(aUSDCBalance >= zSTTReceived, "OCR_Instant::redeemUSDC() aUSDCBalance < zSTTReceived");
         
-        // Calculate how much USDC to provide (1:1 ratio with zSTT burned)
-        IPool_OCR(AAVE_V3_POOL).withdraw(USDC, zSTTReceived, address(this));
-
         // Calculate fee
         uint256 fee = (zSTTReceived * redemptionFeeBIPS) / BIPS;
         uint256 netAmount = zSTTReceived - fee;
 
+        // Calculate how much USDC to provide (1:1 ratio with zSTT burned)
+        IPool_OCR(AAVE_V3_POOL).withdraw(USDC, netAmount, address(this));
+
         // Transfer USDC to user and DAO
-        IERC20(USDC).safeTransfer(owner(), fee);
         IERC20(USDC).safeTransfer(_msgSender(), netAmount);
         
         emit zVLTBurnedForUSDC(_msgSender(), zVLTAmount, netAmount, fee);

--- a/src/misc/InterfacesAggregated.sol
+++ b/src/misc/InterfacesAggregated.sol
@@ -80,7 +80,9 @@ interface ILocker {
 }
 
 interface IZivoeDAO is GenericData {
-    
+    function push(address locker, address asset, uint256 amount, bytes calldata data) external;
+    function pull(address locker, address asset, bytes calldata data) external;
+    function pullPartial(address locker, address asset, uint256 amount, bytes calldata data) external;
 }
 
 interface IZivoeGovernor {
@@ -120,6 +122,7 @@ interface IZivoeGlobals {
     function decreaseDefaults(uint256) external;
     function standardize(uint256, address) external view returns (uint256);
     function adjustedSupplies() external view returns (uint256, uint256);
+    function updateIsLocker(address, bool) external;
 }
 
 interface IZivoeITO is GenericData {


### PR DESCRIPTION
This PR accomplishes the following:
- Implements an `OCR_Instant` locker which facilitates instant redemptions of the `zVLT` token
- The redemptions locker also supports AAVE v3 idle-capital yield generation, fee adjustments, and push/pull full and partial endpoints for DAO interactions